### PR TITLE
Fixed enum settings handling for TorrSpy

### DIFF
--- a/lib/vdlib/torrspy/info.py
+++ b/lib/vdlib/torrspy/info.py
@@ -41,10 +41,10 @@ def settings_get_save_position():
 def add_movies_to_lib():
     s = decode_string(addon_setting('add_movies_to_lib'))
 
-    if s == 1:  # автоматически
+    if s == "1":  # автоматически
         return True
 
-    if s == 2: # нет
+    if s == "2": # нет
         return False
 
     return xbmcgui.Dialog().yesno(addon_title(), translate(32032))
@@ -53,10 +53,10 @@ def add_movies_to_lib():
 def add_tvshows_to_lib():
     s = decode_string(addon_setting('add_tvshows_to_lib'))
 
-    if s == 1: # автоматически
+    if s == "1": # автоматически
         return True
 
-    if s == 2: # нет
+    if s == "2": # нет
         return False
 
     return xbmcgui.Dialog().yesno(addon_title(), translate(32033))


### PR DESCRIPTION
xbmcaddon.Addon().getSetting() returns string values for enum settings, not integers.

The given options did not work, if you selected another option like "No" it did not work.

<img width="2026" height="1312" alt="PXL_20260507_125251936 MP" src="https://github.com/user-attachments/assets/7ee41aaa-b339-4eab-bf59-0f5cee9b97ed" />
