### PR TITLE
TMDB API for up to 3 pages to identify the correct movie

### DIFF
--- a/lib/vdlib/scrappers/movieapi.py
+++ b/lib/vdlib/scrappers/movieapi.py
@@ -831,23 +831,42 @@ class TMDB_API(object):
 
         result = tmdb_query_result()
         from ..util import HTTPError, URLError
-        try:
-            debug("Request is: " + url)
-            data = json.load(urlopen(url))
-            debug("data is: {}".format(data))
-        except (HTTPError, URLError) as e:
-            debug("Error TMDB request")
-            debug(e)
-            return tmdb_query_result()
 
-        if "total_pages" in data:
-            result.total_pages = data["total_pages"]
+        max_pages = int(kwargs.get("max_pages", 1))
+        
+        all_data = []
+        
+        for page in range(1, max_pages + 1):
+            
+            page_url = url
+            
+            if "page=" in page_url:
+                page_url = re.sub(r'page=\d+', f'page={page}', page_url)
+            else:
+                page_url += f"&page={page}"
+                
+            try:
+                debug("Request is: " + page_url)
+                
+                data = json.load(urlopen(page_url))
+                
+                debug("data is: {}".format(data))
+                
+                all_data.append(data)
+                
+            except (HTTPError, URLError) as e:
+                debug("Error TMDB request")
+                debug(e)
+                continue
+                
+        if all_data:
+             result.total_pages = all_data[0].get("total_pages")
 
-        for tag in ["results", "movie_results", "tv_results"]:
-            if tag in data:
+        for data in all_data:
+            for tag in ["results", "movie_results", "tv_results"]:
+                if tag not in data:
+                    continue
                 for r in data[tag]:
-                    if not r["overview"]:
-                        continue
 
                     if "_results" in tag:
                         type = tag.replace("_results", "")

--- a/lib/vdlib/torrspy/detect.py
+++ b/lib/vdlib/torrspy/detect.py
@@ -224,7 +224,7 @@ def find_tmdb_movie_item(video_info, art={}):
     def find_by(title):
         # null = без языка, остальные — коды ISO 639-1 для постеров/фонов
         image_langs = 'null,en,ru,ro,uk,de,fr,es,it,pt,pl,tr,ja,ko,zh,hu,cs,sk'
-        results = TMDB_API.search(title, append_to_response='images,external_ids,credits', include_image_language=image_langs)
+        results = TMDB_API.search(title, append_to_response='images,external_ids,credits', max_pages=3, include_image_language=image_langs)
         if len(results) == 1:
             result = results[0]     # type: tmdb_movie_item
             return result


### PR DESCRIPTION
Sometimes some movies have the same name and you can get the wrong metadata, now the addon will correctly identify it by image from three TMDB pages.

**Before:** 
<img width="3868" height="1203" alt="PXL_20260507_124031255" src="https://github.com/user-attachments/assets/862e0ca2-144c-4221-9da6-4695905460ba" />

**After: Year and Metadata are correctly identified**
<img width="3871" height="1270" alt="PXL_20260507_123538373" src="https://github.com/user-attachments/assets/4147b75e-a18d-43ed-9c31-cdbf148ff52c" />
